### PR TITLE
Add difference() to syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "openscad",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -29,6 +29,12 @@
 		"description": "cylinder",
 		"scope": "source.scad"
 	},
+	"dif": {
+		"prefix": "dif",
+		"body": "difference() {\r\n\t${0}\r\n}",
+		"description": "difference",
+		"scope": "source.scad"
+	},
 	"echo": {
 		"prefix": "echo",
 		"body": "echo(str(\"${1:Variable = }\", ${2:x}));",


### PR DESCRIPTION
[Found this snippet](https://github.com/Sythelux/vscode-lang-scad/commit/eea63446e92aac69056fde33bba3b5d4ef3b41af#diff-21a355f19d529498dec6a0e8b2e937b856e2b58685661aeb9ef2048c8fc8e48d) and I use difference often when using OpenSCAD so this would be handy!