### PR TITLE
added initial languageserver connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -384,6 +384,7 @@
     "dependencies": {
         "command-exists": "^1.2.9",
         "escape-string-regexp": "^4.0.0",
-        "ste-signals": "^1.6.11"
+        "ste-signals": "^1.6.11",
+        "vscode-languageclient": "^7.0.0"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { Cheatsheet } from './cheatsheet';
 import { PreviewManager } from './previewManager';
+import { activateLanguageServer } from './languageclient';
 import { DEBUG } from './config';
 
 // New launch object
@@ -92,6 +93,8 @@ export function activate(context: vscode.ExtensionContext): void {
             },
         });
     }
+
+    activateLanguageServer(context);
 }
 
 // Called when extension is deactivated

--- a/src/languageclient.ts
+++ b/src/languageclient.ts
@@ -1,0 +1,81 @@
+import * as vscode from 'vscode';
+import * as languageclient from 'vscode-languageclient/node';
+import * as net from 'net';
+
+let langclient: languageclient.LanguageClient;
+
+export function activateLanguageServer(context: vscode.ExtensionContext): void {
+    const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(
+        'OpenSCAD'
+    );
+    // The server is implemented in node
+    const connectionInfo = {
+        port: 23725, // 0x5cad
+        host: 'localhost',
+    };
+
+    const serverOptions = () => {
+        // Connect to language server via socket
+        const socket = net.connect(connectionInfo);
+        const result: languageclient.StreamInfo = {
+            writer: socket,
+            reader: socket,
+        };
+
+        outputChannel.appendLine(
+            '[client] Connecting to openscad on port ' + connectionInfo.port
+        );
+        console.log(
+            'Opening connection to ',
+            connectionInfo.host + ':' + connectionInfo.port
+        );
+
+        return Promise.resolve(result);
+    };
+
+    // Options to control the language client
+    const clientOptions: languageclient.LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'scad' }],
+        synchronize: {},
+        outputChannel,
+        outputChannelName: 'OpenSCAD',
+        revealOutputChannelOn: languageclient.RevealOutputChannelOn.Info,
+    };
+
+    // Create the language client and start the client.
+    langclient = new languageclient.LanguageClient(
+        'openscad-lsp',
+        'OpenSCAD Language Server',
+        serverOptions,
+        clientOptions
+    );
+    langclient.registerProposedFeatures();
+
+    // enable tracing (.Off, .Messages, Verbose)
+    langclient.trace = languageclient.Trace.Verbose;
+
+    // Start the client. This will also launch the server
+    const disposable = langclient.start();
+
+    // Push the disposable to the context's subscriptions so that the
+    // client can be deactivated on extension deactivation
+    context.subscriptions.push(disposable);
+
+    langclient.onReady().then(() => {
+        outputChannel.appendLine('[client] Connection has been established');
+
+        // Only register the commands when the connection has been established.
+        context.subscriptions.push(
+            vscode.commands.registerCommand('openscad.lsp.preview', () => {
+                const editor = vscode.window.activeTextEditor;
+                if (editor) {
+                    langclient.sendRequest('$openscad/preview', {
+                        uri: editor.document.uri.toString(),
+                    });
+                }
+            })
+        );
+
+        vscode.commands.executeCommand('openscad.lsp.preview');
+    });
+}


### PR DESCRIPTION
Let me begin implementing #16 (althought it is not yet merged upstream...)
This is my first - and last - typescript/vscode extension I will ever write, so any help is greatly appreciated!

- [X] Add connection to a running OpenSCAD instance
   - [X] Receive Diagnostics
   - [ ] Trigger a preview in the linked instance (registered as command `openscad.lsp.preview`)
- [ ] Query the installed openscad version if it does/does not support the LSP magic (check if it starts with command line flag `--lsp-listen`, which is the switch for the languageserver)
- [ ] If the detected version supports lsp, change all existing commands that currently start a new openscad instance to start relay to the linked instance. (this *will* require more support upstream, but thats what I am here for)
- [ ] Add the option to Download the latest release / current snapshot build.


closes #16