### PR TITLE
Update poly snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -127,7 +127,7 @@
 	},
 	"poly": {
 		"prefix": "poly",
-		"body": "polyhedron(points=[${1:[0,0,0],[100,0,0],[0,100,0],[0,100,100]}], triangles=[${2:[0,1,2],[1,0,3],[0,2,3],[2,1,3]}]);",
+		"body": "polyhedron(points=[${1:[0,0,0],[100,0,0],[0,100,0],[0,100,100]}], faces=[${2:[0,1,2],[1,0,3],[0,2,3],[2,1,3]}]);",
 		"description": "polyhedron",
 		"scope": "source.scad"
 	},


### PR DESCRIPTION
The `triangles` parameter is deprecated and `faces` should be used instead.