### PR TITLE
Updated 'on' event and node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,11 @@
 # Based on: https://github.com/HaaLeo/publish-vscode-extension
 name: Deploy Extension
 
+# Run when new version ('v*') tag is created 
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   deploy:
@@ -15,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: npm ci
         
       # Pulbish to Open VSX Registry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,3 +37,9 @@ jobs:
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
           packagePath: ''
+          
+      # Download the built .vsix extension file
+      - name: Download .VSIX file
+        uses: actions/download-artifact@v2.0.8
+        with:
+          path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,15 +8,18 @@ on:
     tags:
       - "v*"
 
+env:
+  NODE_VERSION: '12.x'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{env.NODE_VERSION}}
       - run: npm ci
 
       # Check (and update if necessary) package.json version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           node-version: 14
       - run: npm ci
+
+      # Check (and update if necessary) package.json version
+      - name: Check package version
+        uses: technote-space/package-version-check-action@v1
         
       # Pulbish to Open VSX Registry
       - name: Publish to Open VSX Registry


### PR DESCRIPTION
- Runs on version tags only ( 'v*' )
- Runs on node version 12 to be consistent with vscode version
- Download .vsix artifact