### PR TITLE
Implement better logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Implemented logging-service.ts based on the one found in the prettier/prettier-vscode. This should make it easier for troubleshooting issues in the future.
+- `openscad.showOutput` command to display the output channel.
+- `openscad.logLevel` configuration to set the output channel log level.
+
+### Fixed
+
+- Bug with `openscad.launchPath` using an empty value. Should help with
+  [#49](https://github.com/Antyos/vscode-openscad/issues/49) and
+  [#50](https://github.com/Antyos/vscode-openscad/issues/50)
+
 ## [[1.2.1](https://github.com/Antyos/vscode-openscad/releases/tag/v1.2.1)] - (2023-07-26)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
                     "light": "./media/icons/export-light.svg",
                     "dark": "./media/icons/export-dark.svg"
                 }
+            },
+            {
+                "command": "openscad.showOutput",
+                "title": "Show OpenSCAD output channel",
+                "category": "OpenSCAD"
             }
         ],
         "menus": {
@@ -243,6 +248,18 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show message when a preview is killed."
+                },
+                "openscad.logLevel": {
+                    "type": "string",
+                    "default": "INFO",
+                    "description": "Log level to output to OpenSCAD output channel.",
+                    "enum": [
+                        "Debug",
+                        "Info",
+                        "Warn",
+                        "Error",
+                        "None"
+                    ]
                 },
                 "openscad.export.preferredExportFileExtension": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -254,11 +254,11 @@
                     "default": "INFO",
                     "description": "Log level to output to OpenSCAD output channel.",
                     "enum": [
-                        "Debug",
-                        "Info",
-                        "Warn",
-                        "Error",
-                        "None"
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "NONE"
                     ]
                 },
                 "openscad.export.preferredExportFileExtension": {

--- a/src/cheatsheet/cheatsheet-content.ts
+++ b/src/cheatsheet/cheatsheet-content.ts
@@ -169,7 +169,7 @@ export class CheatsheetContent {
             )
             .then((uint8array) => {
                 const fileContent = new TextDecoder().decode(uint8array);
-                // console.log(fileContent.toString());
+                // this.loggingService.logDebug(fileContent.toString());
                 return parse(fileContent.toString());
             });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@
  * Interface containing all configurations that are used by Typescript parts of extension
  *----------------------------------------------------------------------------*/
 
+import { LogLevel } from './logging-service';
+
 /** Extension config values */
 export interface ScadConfig {
     openscadPath?: string;
@@ -17,4 +19,5 @@ export interface ScadConfig {
     displayInStatusBar?: string;
     colorScheme?: string;
     openToSide?: string;
+    logLevel?: LogLevel;
 }

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -95,7 +95,7 @@ export function activate(context: vscode.ExtensionContext): void {
         Cheatsheet.onDidChangeConfiguration(config); // Update the cheatsheet with new config
         previewManager.onDidChangeConfiguration(config); // Update launcher with new config
         loggingService.logDebug('Config change!');
-        loggingService.setOutputLevel(config.get('logLevel') ?? 'None');
+        loggingService.setOutputLevel(config.get('logLevel') ?? 'NONE');
     }
 }
 

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -36,7 +36,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 loggingService.setOutputLevel(
                     vscode.workspace
                         .getConfiguration('openscad')
-                        .get('logLevel') ?? 'None'
+                        .get('logLevel') ?? 'NONE'
                 );
             }
         })

--- a/src/logging-service.ts
+++ b/src/logging-service.ts
@@ -1,11 +1,11 @@
 import { window } from 'vscode';
 
 const LOG_LEVEL = {
-    DEBUG: 'Debug',
-    INFO: 'Info',
-    WARN: 'Warn',
-    ERROR: 'Error',
-    NONE: 'None',
+    DEBUG: 'DEBUG',
+    INFO: 'INFO',
+    WARN: 'WARN',
+    ERROR: 'ERROR',
+    NONE: 'NONE',
 } as const;
 
 type ObjectValues<T> = T[keyof T];

--- a/src/logging-service.ts
+++ b/src/logging-service.ts
@@ -1,0 +1,125 @@
+import { window } from 'vscode';
+
+const LOG_LEVEL = {
+    DEBUG: 'Debug',
+    INFO: 'Info',
+    WARN: 'Warn',
+    ERROR: 'Error',
+    NONE: 'None',
+} as const;
+
+type ObjectValues<T> = T[keyof T];
+
+export type LogLevel = ObjectValues<typeof LOG_LEVEL>;
+
+export class LoggingService {
+    private outputChannel = window.createOutputChannel('OpenSCAD');
+    private logLevel: LogLevel = LOG_LEVEL.INFO;
+
+    public setOutputLevel(logLevel: LogLevel) {
+        this.logLevel = logLevel;
+    }
+
+    /**
+     * Append messages to the output channel and format it with a title
+     *
+     * @param message The message to append to the output channel
+     */
+    public logDebug(message: string, data?: unknown): void {
+        if (
+            this.logLevel === LOG_LEVEL.NONE ||
+            this.logLevel === LOG_LEVEL.INFO ||
+            this.logLevel === LOG_LEVEL.WARN ||
+            this.logLevel === LOG_LEVEL.ERROR
+        ) {
+            return;
+        }
+        this.logMessage(message, LOG_LEVEL.DEBUG);
+        if (data) {
+            this.logObject(data);
+        }
+    }
+
+    /**
+     * Append messages to the output channel and format it with a title
+     *
+     * @param message The message to append to the output channel
+     */
+    public logInfo(message: string, data?: unknown): void {
+        if (
+            this.logLevel === LOG_LEVEL.NONE ||
+            this.logLevel === LOG_LEVEL.WARN ||
+            this.logLevel === LOG_LEVEL.ERROR
+        ) {
+            return;
+        }
+        this.logMessage(message, LOG_LEVEL.INFO);
+        if (data) {
+            this.logObject(data);
+        }
+    }
+
+    /**
+     * Append messages to the output channel and format it with a title
+     *
+     * @param message The message to append to the output channel
+     */
+    public logWarning(message: string, data?: unknown): void {
+        if (
+            this.logLevel === LOG_LEVEL.NONE ||
+            this.logLevel === LOG_LEVEL.ERROR
+        ) {
+            return;
+        }
+        this.logMessage(message, LOG_LEVEL.WARN);
+        if (data) {
+            this.logObject(data);
+        }
+    }
+
+    public logError(message: string, error?: unknown) {
+        if (this.logLevel === LOG_LEVEL.NONE) {
+            return;
+        }
+        this.logMessage(message, LOG_LEVEL.ERROR);
+        if (typeof error === 'string') {
+            // Errors as a string usually only happen with
+            // plugins that don't return the expected error.
+            this.outputChannel.appendLine(error);
+        } else if (error instanceof Error) {
+            if (error?.message) {
+                this.logMessage(error.message, LOG_LEVEL.ERROR);
+            }
+            if (error?.stack) {
+                this.outputChannel.appendLine(error.stack);
+            }
+        } else if (error) {
+            this.logObject(error);
+        }
+    }
+
+    public show() {
+        this.outputChannel.show();
+    }
+
+    private logObject(data: unknown): void {
+        // const message = JSON.parser
+        //   .format(JSON.stringify(data, null, 2), {
+        //     parser: "json",
+        //   })
+        //   .trim();
+        const message = JSON.stringify(data, undefined, 4);
+
+        this.outputChannel.appendLine(message);
+    }
+
+    /**
+     * Append messages to the output channel and format it with a title
+     *
+     * @param message The message to append to the output channel
+     */
+    private logMessage(message: string, logLevel: LogLevel): void {
+        const title = new Date().toLocaleTimeString();
+        this.outputChannel.appendLine(`["${logLevel}" - ${title}] ${message}`);
+    }
+}

--- a/src/preview/openscad-exe.ts
+++ b/src/preview/openscad-exe.ts
@@ -9,6 +9,7 @@ import { type } from 'os'; // node:os
 import { promisify } from 'util';
 
 import commandExists = require('command-exists');
+import { LoggingService } from 'src/logging-service';
 
 const execFile = promisify(child.execFile);
 
@@ -30,6 +31,8 @@ export class OpenscadExecutableManager {
     private openscadExecutable?: OpenscadExecutable;
     private openscadPath?: string;
     private arguments_: string[] = [];
+
+    public constructor(private loggingService: LoggingService) {}
 
     private async getOpenscadVersion(
         openscadPath: string,
@@ -70,7 +73,7 @@ export class OpenscadExecutableManager {
         // Use platform default if not specified
         const openscadPath = this.getPath();
 
-        console.log(`Path: '${openscadPath}'`); // DEBUG
+        this.loggingService.logInfo(`Using OpenSCAD path: '${openscadPath}'`);
 
         // TODO: Replace with something less nested
         commandExists(openscadPath, async (error: null, exists: boolean) => {
@@ -86,6 +89,10 @@ export class OpenscadExecutableManager {
                 filePath: openscadPath,
                 arguments_: this.arguments_,
             };
+            this.loggingService.logDebug(
+                'Using OpenSCAD:',
+                this.openscadExecutable
+            );
         });
     }
 

--- a/src/preview/preview-manager.ts
+++ b/src/preview/preview-manager.ts
@@ -14,9 +14,13 @@ import {
     ExportFileExtensionList,
 } from 'src/export/export-file-extensions';
 import { VariableResolver } from 'src/export/variable-resolver';
+import { LoggingService } from 'src/logging-service';
+import {
+    OpenscadExecutable,
+    OpenscadExecutableManager,
+} from 'src/preview/openscad-exe';
 import { Preview } from 'src/preview/preview';
 import { PreviewStore } from 'src/preview/preview-store';
-import { OpenscadExecutable, OpenscadExecutableManager } from './openscad-exe';
 
 /** PreviewItems used for `scad.kill` quick pick menu */
 class PreviewItem implements vscode.QuickPickItem {
@@ -45,10 +49,10 @@ const mNoPreviews = new MessageItem('No open previews');
 
 /** Manager of multiple Preview objects */
 export class PreviewManager {
-    private previewStore = new PreviewStore();
+    private previewStore: PreviewStore;
     private config: ScadConfig = {};
-    private variableResolver = new VariableResolver();
-    private openscadExecutableManager = new OpenscadExecutableManager();
+    private variableResolver: VariableResolver;
+    private openscadExecutableManager: OpenscadExecutableManager;
 
     // public activate() {}
 
@@ -61,7 +65,9 @@ export class PreviewManager {
         for (const uri of Array.isArray(allUris) ? allUris : [mainUri]) {
             let resource: vscode.Uri;
 
-            // console.log(`openFile: { main: ${mainUri}, all: ${allUris}, args: ${args}}`);   // DEBUG
+            this.loggingService.logDebug(
+                `openFile: { main: ${mainUri}, all: ${allUris}, args: ${arguments_}}`
+            ); // DEBUG
 
             // If uri not given, try opening activeTextEditor
             if (!(uri instanceof vscode.Uri)) {
@@ -82,7 +88,7 @@ export class PreviewManager {
             )
                 return;
 
-            console.log(`uri: ${resource}`); // DEBUG
+            this.loggingService.logDebug(`uri: ${resource}`); // DEBUG
 
             // Create and add new OpenSCAD preview to PreviewStore
             this.previewStore.createAndAdd(
@@ -190,7 +196,7 @@ export class PreviewManager {
             )
                 return;
 
-            console.log(`Export uri: ${resource}`); // DEBUG
+            this.loggingService.logInfo(`Export uri: ${resource}`);
 
             this.previewStore.createAndAdd(
                 this.openscadExecutableManager.executable,
@@ -253,7 +259,7 @@ export class PreviewManager {
     public killAll(): void {
         // Check that there are open previews
         if (this.previewStore.size <= 0) {
-            console.error('No open previews');
+            this.loggingService.logError('No open previews');
             vscode.window.showInformationMessage('No open previews.');
             return;
         }
@@ -263,7 +269,13 @@ export class PreviewManager {
     }
 
     /** Constructor */
-    public constructor() {
+
+    public constructor(private loggingService: LoggingService) {
+        this.previewStore = new PreviewStore(this.loggingService);
+        this.variableResolver = new VariableResolver(this.loggingService);
+        this.openscadExecutableManager = new OpenscadExecutableManager(
+            this.loggingService
+        );
         // Load configutation
         this.onDidChangeConfiguration(
             vscode.workspace.getConfiguration('openscad')
@@ -292,7 +304,7 @@ export class PreviewManager {
             'export.useAutoNamingInSaveDialogues'
         );
 
-        console.log(this.config.launchArgs);
+        this.loggingService.logDebug('Launch args:', this.config.launchArgs);
 
         this.openscadExecutableManager.updateScadPath(
             this.config.openscadPath,
@@ -342,7 +354,7 @@ export class PreviewManager {
             : path.join(path.dirname(resource.fsPath), fileName); // Full file path
         const resourceNewExtension = vscode.Uri.file(filePath); // Resource URI with new file extension
 
-        console.log(`Opening Save Dialogue to: ${filePath}`);
+        this.loggingService.logDebug(`Opening Save Dialogue to: ${filePath}`);
 
         // Open save dialogue
         const savedUri = await vscode.window.showSaveDialog({
@@ -365,9 +377,9 @@ export class PreviewManager {
             // Error message for default
             const openscadPath = this.openscadExecutableManager.getPath();
 
-            console.error(
+            this.loggingService.logError(
                 `Path to openscad command is invalid: "${openscadPath}"`
-            ); // DEBUG
+            );
             vscode.window.showErrorMessage(
                 `Cannot find the command: "${openscadPath}". Make sure OpenSCAD is installed. You may need to specify the installation path under \`Settings > OpenSCAD > Launch Path\``
             );
@@ -379,7 +391,9 @@ export class PreviewManager {
             this.previewStore.size >= this.previewStore.maxPreviews &&
             this.previewStore.maxPreviews > 0
         ) {
-            console.error('Max number of OpenSCAD previews already open.'); // DEBUG
+            this.loggingService.logError(
+                'Max number of OpenSCAD previews already open.'
+            );
             vscode.window.showErrorMessage(
                 'Max number of OpenSCAD previews already open. Try increasing the max instances in the config.'
             );
@@ -388,7 +402,9 @@ export class PreviewManager {
 
         // Make sure file is not already open
         if (this.previewStore.get(resource, PreviewStore.hasGui(arguments_))) {
-            console.log(`File is already open: "${resource.fsPath}"`);
+            this.loggingService.logInfo(
+                `File is already open: "${resource.fsPath}"`
+            );
             vscode.window.showInformationMessage(
                 `${path.basename(resource.fsPath)} is already open: "${
                     resource.fsPath

--- a/src/preview/preview-store.ts
+++ b/src/preview/preview-store.ts
@@ -7,6 +7,7 @@
 import { basename } from 'path'; // node:path
 import * as vscode from 'vscode';
 
+import { LoggingService } from 'src/logging-service';
 import { OpenscadExecutable } from './openscad-exe';
 import { Preview } from './preview';
 
@@ -33,7 +34,10 @@ export class PreviewStore /* extends vscode.Disposable */ {
     }
 
     /** Create a new PreviewStore with a max number of previews */
-    public constructor(maxPreviews = 0) {
+    public constructor(
+        private readonly loggingService: LoggingService,
+        maxPreviews = 0
+    ) {
         this._maxPreviews = maxPreviews;
         this.setAreOpenPreviews(false);
     }
@@ -72,6 +76,7 @@ export class PreviewStore /* extends vscode.Disposable */ {
         }
 
         const preview = new Preview(
+            this.loggingService,
             openscadExecutable,
             uri,
             hasGui,
@@ -139,7 +144,7 @@ export class PreviewStore /* extends vscode.Disposable */ {
 
                 // Cancel export
                 token.onCancellationRequested(() => {
-                    console.log('Canceled Export');
+                    this.loggingService.logInfo('Canceled Export');
                     this.delete(preview);
                 });
 

--- a/src/preview/preview.ts
+++ b/src/preview/preview.ts
@@ -7,7 +7,8 @@
 import * as child from 'child_process'; // node:child_process
 import * as vscode from 'vscode';
 
-import { OpenscadExecutable } from './openscad-exe';
+import { LoggingService } from 'src/logging-service';
+import { OpenscadExecutable } from 'src/preview/openscad-exe';
 
 /** Open an instance of OpenSCAD to preview a file */
 export class Preview {
@@ -17,6 +18,7 @@ export class Preview {
 
     /** Launch an instance of OpenSCAD to prview a file */
     constructor(
+        private readonly loggingService: LoggingService,
         private readonly openscadExecutable: OpenscadExecutable,
         public readonly uri: vscode.Uri,
         public readonly hasGui: boolean,
@@ -32,7 +34,7 @@ export class Preview {
             this.uri.fsPath,
         ];
 
-        console.log(`commangArgs: ${commandArguments}`); // DEBUG
+        this.loggingService.logDebug(`commandArgs: ${commandArguments}`); // DEBUG
 
         // New process
         this._process = child.execFile(
@@ -41,8 +43,8 @@ export class Preview {
             (error, stdout, stderr) => {
                 // If there's an error
                 if (error) {
-                    // console.error(`exec error: ${error}`);
-                    console.error(`stderr: ${stderr}`); // DEBUG
+                    // this.loggingService.logError(`exec error: ${error}`);
+                    this.loggingService.logError(`stderr: ${stderr}`); // DEBUG
                     vscode.window.showErrorMessage(stderr); // Display error message
                 }
                 // No error
@@ -51,12 +53,12 @@ export class Preview {
                     // If there is no error, assume stderr should be treated as stdout
                     // For more info. see: https://github.com/openscad/openscad/issues/3358
                     const message = stdout || stderr;
-                    console.log(`stdout: ${message}`); // DEBUG
+                    this.loggingService.logDebug(`stdout: ${message}`); // DEBUG
 
                     vscode.window.showInformationMessage(message); // Display info
                 }
 
-                // console.log(`real stdout: ${stdout}`);    // DEBUG
+                // this.loggingService.logDebug(`real stdout: ${stdout}`);    // DEBUG
 
                 this._isRunning = false;
                 // Dispatch 'onKilled' event


### PR DESCRIPTION
Implemented `logging-service.ts` based on the one found in the [prettier/prettier-vscode](https://github.com/prettier/prettier-vscode/blob/main/src/LoggingService.ts). This should make it easier for troubleshooting issues in the future.

## Added
- `openscad.logLevel` configuration
- `openscad.showOutput` command
