### PR TITLE
Fix incorrect deprecation warnings

### DIFF
--- a/src/preview/preview-manager.ts
+++ b/src/preview/preview-manager.ts
@@ -376,6 +376,7 @@ export class PreviewManager {
         const autoNamingFormat = config.get<string>('export.autoNamingFormat');
         if (
             autoNamingFormat !== undefined &&
+            autoNamingFormat !== null &&
             this.config.exportNameFormat === DEFAULT_CONFIG.exportNameFormat
         ) {
             this.loggingService.logWarning(
@@ -392,6 +393,7 @@ export class PreviewManager {
         );
         if (
             useAutoNamingExport !== undefined &&
+            useAutoNamingExport !== null &&
             this.config.skipSaveDialog === DEFAULT_CONFIG.skipSaveDialog
         ) {
             this.loggingService.logWarning(


### PR DESCRIPTION
Thanks for this extension, it makes working with OpenSCAD more enjoyable! After #58 was released, I started seeing consistent deprecation warnings about properties I never set and that do not appear in my `settings.json`.

I did some debugging, and it turns out that when a property is defined in `package.json`, the `config.get()` function returns `null` if the property is unset instead of `undefined`. It appears `undefined` is reserved for properties that are actually not defined for the extension, although the VSCode API docs don't mention this (maybe it's a bug with VSCode 1.85.2?)

As a result, users who never set the deprecated export options would still see deprecation notifications when the extension processed its config. Fixing the checks to handle `null` seemed better than removing the property definitions, since I assume the property definitions are still useful for users who _did_ configure the old properties.